### PR TITLE
Initialize Playwright Guice framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Execute the following command to run the test suite:
 mvn test
 ```
 
+### Example Test
+
+The project includes a sample test (`ExampleTest`) that opens the
+[Playwright](https://playwright.dev/) website and asserts that the page
+title contains the word `Playwright`. This demonstrates using the Guice
+injection setup provided in `BaseTest` and the `PlaywrightModule`.
+
 ## Project Structure
 
 Typical Maven layout is recommended:

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>playwright-guice</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <junit.version>5.10.0</junit.version>
+        <playwright.version>1.42.0</playwright.version>
+        <guice.version>7.0.0</guice.version>
+    </properties>
+
+    <dependencies>
+        <!-- Playwright for Java -->
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>${playwright.version}</version>
+        </dependency>
+        <!-- JUnit Jupiter API and Engine -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Google Guice -->
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${guice.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/framework/PlaywrightModule.java
+++ b/src/main/java/com/example/framework/PlaywrightModule.java
@@ -1,0 +1,24 @@
+package com.example.framework;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Playwright;
+import javax.inject.Singleton;
+
+public class PlaywrightModule extends AbstractModule {
+    @Provides
+    @Singleton
+    Playwright providePlaywright() {
+        return Playwright.create();
+    }
+
+    @Provides
+    @Singleton
+    Browser provideBrowser(Playwright playwright) {
+        BrowserType.LaunchOptions options = new BrowserType.LaunchOptions();
+        options.setHeadless(true);
+        return playwright.chromium().launch(options);
+    }
+}

--- a/src/test/java/com/example/tests/BaseTest.java
+++ b/src/test/java/com/example/tests/BaseTest.java
@@ -1,0 +1,35 @@
+package com.example.tests;
+
+import com.example.framework.PlaywrightModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.Page;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public abstract class BaseTest {
+    protected static Injector injector;
+    protected static Browser browser;
+    protected static Page page;
+
+    @BeforeAll
+    static void setUpBase() {
+        injector = Guice.createInjector(new PlaywrightModule());
+        browser = injector.getInstance(Browser.class);
+        page = browser.newPage();
+    }
+
+    @AfterAll
+    static void tearDownBase() {
+        if (page != null) {
+            page.close();
+        }
+        if (browser != null) {
+            browser.close();
+        }
+        if (injector != null) {
+            injector = null;
+        }
+    }
+}

--- a/src/test/java/com/example/tests/ExampleTest.java
+++ b/src/test/java/com/example/tests/ExampleTest.java
@@ -1,0 +1,13 @@
+package com.example.tests;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExampleTest extends BaseTest {
+    @Test
+    void homePageHasTitle() {
+        page.navigate("https://playwright.dev/");
+        String title = page.title();
+        assertTrue(title.contains("Playwright"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Maven project with Playwright, Guice and JUnit
- create PlaywrightModule and base test setup
- add ExampleTest that loads playwright.dev
- document the example test in README

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_687055ba37e48333aa75965a3fa1dd15