### PR TITLE
Add configuration support for Playwright setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ The project includes a sample test (`ExampleTest`) that opens the
 title contains the word `Playwright`. This demonstrates using the Guice
 injection setup provided in `BaseTest` and the `PlaywrightModule`.
 
+### Configuration
+
+Runtime configuration is stored in `src/main/resources/config.properties`.
+Currently the following settings are supported:
+
+```
+headless=true        # Launch browser in headless mode
+timeoutInSeconds=10  # Default timeout used by `WaitUtil`
+```
+
 ## Project Structure
 
 Typical Maven layout is recommended:

--- a/src/main/java/com/example/framework/Config.java
+++ b/src/main/java/com/example/framework/Config.java
@@ -1,0 +1,31 @@
+package com.example.framework;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Properties;
+
+public final class Config {
+    private static final Properties PROPS = new Properties();
+
+    static {
+        try (InputStream is = Config.class.getClassLoader().getResourceAsStream("config.properties")) {
+            if (is != null) {
+                PROPS.load(is);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load configuration", e);
+        }
+    }
+
+    private Config() {}
+
+    public static boolean isHeadless() {
+        return Boolean.parseBoolean(PROPS.getProperty("headless", "true"));
+    }
+
+    public static Duration waitTimeout() {
+        String val = PROPS.getProperty("timeoutInSeconds", "10");
+        return Duration.ofSeconds(Long.parseLong(val));
+    }
+}

--- a/src/main/java/com/example/framework/PlaywrightModule.java
+++ b/src/main/java/com/example/framework/PlaywrightModule.java
@@ -5,6 +5,8 @@ import com.google.inject.Provides;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Playwright;
+
+import static com.example.framework.Config.isHeadless;
 import javax.inject.Singleton;
 
 public class PlaywrightModule extends AbstractModule {
@@ -18,7 +20,7 @@ public class PlaywrightModule extends AbstractModule {
     @Singleton
     Browser provideBrowser(Playwright playwright) {
         BrowserType.LaunchOptions options = new BrowserType.LaunchOptions();
-        options.setHeadless(true);
+        options.setHeadless(isHeadless());
         return playwright.chromium().launch(options);
     }
 }

--- a/src/main/java/com/example/framework/WaitUtil.java
+++ b/src/main/java/com/example/framework/WaitUtil.java
@@ -1,0 +1,31 @@
+package com.example.framework;
+
+import com.microsoft.playwright.Page;
+import java.time.Duration;
+import java.util.function.Predicate;
+
+public final class WaitUtil {
+    private static final Duration TIMEOUT = Config.waitTimeout();
+
+    private WaitUtil() {}
+
+    public static void waitForSelector(Page page, String selector) {
+        page.waitForSelector(selector, new Page.WaitForSelectorOptions().setTimeout(TIMEOUT.toMillis()));
+    }
+
+    public static void waitUntil(Page page, Predicate<Page> condition) {
+        long end = System.currentTimeMillis() + TIMEOUT.toMillis();
+        while (System.currentTimeMillis() < end) {
+            if (condition.test(page)) {
+                return;
+            }
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+        throw new RuntimeException("Condition not met within " + TIMEOUT);
+    }
+}

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,0 +1,3 @@
+headless=true
+# Timeout in seconds used by WaitUtil
+timeoutInSeconds=10

--- a/src/test/java/com/example/tests/ExampleTest.java
+++ b/src/test/java/com/example/tests/ExampleTest.java
@@ -2,11 +2,13 @@ package com.example.tests;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
+import com.example.framework.WaitUtil;
 
 class ExampleTest extends BaseTest {
     @Test
     void homePageHasTitle() {
         page.navigate("https://playwright.dev/");
+        WaitUtil.waitForSelector(page, "text=Get started");
         String title = page.title();
         assertTrue(title.contains("Playwright"));
     }


### PR DESCRIPTION
## Summary
- allow runtime configuration via `config.properties`
- read headless and timeout settings using new `Config` class
- add `WaitUtil` helper that respects configured timeout
- update `PlaywrightModule` to launch browser based on config
- demonstrate waiting in `ExampleTest`
- document configuration file in README

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687086800a9883338dd528b2e51361c2