### PR TITLE
Enable parallel execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project is a template for building a test automation framework in Java usin
 - **Google Guice** for dependency injection
 - **Maven** to handle builds and dependency resolution
 - Example structure for page objects and tests
+- **Parallel test execution** enabled via JUnit 5
 
 ## Getting Started
 
@@ -32,6 +33,9 @@ Execute the following command to run the test suite:
 ```bash
 mvn test
 ```
+
+Tests run in parallel by default. The parallel execution settings are defined in
+`src/test/resources/junit-platform.properties`.
 
 ### Example Test
 

--- a/src/test/java/com/example/tests/BaseTest.java
+++ b/src/test/java/com/example/tests/BaseTest.java
@@ -4,27 +4,43 @@ import com.example.framework.PlaywrightModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.Page;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class BaseTest {
     protected static Injector injector;
     protected static Browser browser;
-    protected static Page page;
+    protected BrowserContext context;
+    protected Page page;
 
     @BeforeAll
     static void setUpBase() {
         injector = Guice.createInjector(new PlaywrightModule());
         browser = injector.getInstance(Browser.class);
-        page = browser.newPage();
+    }
+
+    @BeforeEach
+    void setUp() {
+        context = browser.newContext();
+        page = context.newPage();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (page != null) {
+            page.close();
+        }
+        if (context != null) {
+            context.close();
+        }
     }
 
     @AfterAll
     static void tearDownBase() {
-        if (page != null) {
-            page.close();
-        }
         if (browser != null) {
             browser.close();
         }

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.parallel.mode.classes.default = concurrent


### PR DESCRIPTION
## Summary
- allow tests to run concurrently
- open a new browser context and page per test
- document JUnit 5 parallel execution settings

## Testing
- `mvn test` *(fails: `command not found: mvn`)*

------
https://chatgpt.com/codex/tasks/task_e_68708bb952048333b0bcceb4406d84eb