### PR TITLE
Add parallel JUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ mvn test
 ```
 
 Tests run in parallel by default. The parallel execution settings are defined in
-`src/test/resources/junit-platform.properties`.
+`src/test/resources/junit-platform.properties`. You can control the number of
+parallel threads by editing the property
+`junit.jupiter.execution.parallel.config.fixed.parallelism` in this file.
 
 ### Example Test
 

--- a/src/test/java/com/example/tests/AnotherInMemoryTest.java
+++ b/src/test/java/com/example/tests/AnotherInMemoryTest.java
@@ -1,0 +1,12 @@
+package com.example.tests;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnotherInMemoryTest extends BaseTest {
+    @Test
+    void secondPageTitle() {
+        page.setContent("<html><head><title>Second Page</title></head><body></body></html>");
+        assertEquals("Second Page", page.title());
+    }
+}

--- a/src/test/java/com/example/tests/InMemoryPageTest.java
+++ b/src/test/java/com/example/tests/InMemoryPageTest.java
@@ -1,0 +1,19 @@
+package com.example.tests;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class InMemoryPageTest extends BaseTest {
+    @Test
+    void titleIsReturned() {
+        page.setContent("<html><head><title>My Page</title></head><body></body></html>");
+        assertEquals("My Page", page.title());
+    }
+
+    @Test
+    void elementIsVisible() {
+        page.setContent("<html><head><title>Element</title></head><body><button id='btn'>Press</button></body></html>");
+        com.example.framework.WaitUtil.waitForSelector(page, "#btn");
+        assertTrue(page.isVisible("#btn"));
+    }
+}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,3 +1,5 @@
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = concurrent
 junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.config.strategy = fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism = 4


### PR DESCRIPTION
## Summary
- add additional sample tests for parallel execution
- document how to configure parallel thread count
- set fixed parallelism in junit-platform.properties

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68708de2dcac8333b17317607d8ec390