### PR TITLE
Fix concurrency issue in BaseTest

### DIFF
--- a/src/test/java/com/example/tests/BaseTest.java
+++ b/src/test/java/com/example/tests/BaseTest.java
@@ -10,15 +10,17 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class BaseTest {
-    protected static Injector injector;
-    protected static Browser browser;
+    protected Injector injector;
+    protected Browser browser;
     protected BrowserContext context;
     protected Page page;
 
     @BeforeAll
-    static void setUpBase() {
+    void setUpBase() {
         injector = Guice.createInjector(new PlaywrightModule());
         browser = injector.getInstance(Browser.class);
     }
@@ -40,7 +42,7 @@ public abstract class BaseTest {
     }
 
     @AfterAll
-    static void tearDownBase() {
+    void tearDownBase() {
         if (browser != null) {
             browser.close();
         }


### PR DESCRIPTION
## Summary
- make Playwright browser and injector instance fields
- annotate BaseTest with `@TestInstance(PER_CLASS)`
- adjust lifecycle methods to be non-static

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709101fe9c8333a3a7d5aff5488709