### PR TITLE
Add parallel debug test

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Tests run in parallel by default. The parallel execution settings are defined in
 parallel threads by editing the property
 `junit.jupiter.execution.parallel.config.fixed.parallelism` in this file.
 
+If you want to observe browser windows during execution, set `headless=false`
+in `src/main/resources/config.properties`.
+
+For debugging parallel execution a utility test `ParallelDebugTest` is
+included. Each of its methods logs the current thread and waits a few seconds so
+overlapping execution becomes apparent in the console output.
+
 ### Example Test
 
 The project includes a sample test (`ExampleTest`) that opens the

--- a/src/test/java/com/example/tests/ParallelDebugTest.java
+++ b/src/test/java/com/example/tests/ParallelDebugTest.java
@@ -1,0 +1,22 @@
+package com.example.tests;
+
+import org.junit.jupiter.api.Test;
+import java.util.logging.Logger;
+
+class ParallelDebugTest extends BaseTest {
+    private static final Logger logger = Logger.getLogger(ParallelDebugTest.class.getName());
+
+    @Test
+    void slowTestOne() throws InterruptedException {
+        logger.info(() -> "Start slowTestOne on " + Thread.currentThread().getName());
+        Thread.sleep(3000);
+        logger.info(() -> "End slowTestOne on " + Thread.currentThread().getName());
+    }
+
+    @Test
+    void slowTestTwo() throws InterruptedException {
+        logger.info(() -> "Start slowTestTwo on " + Thread.currentThread().getName());
+        Thread.sleep(3000);
+        logger.info(() -> "End slowTestTwo on " + Thread.currentThread().getName());
+    }
+}


### PR DESCRIPTION
## Summary
- add `ParallelDebugTest` with logger output and deliberate delay
- document headful mode and the debug test in README

## Testing
- `which mvn`

------
https://chatgpt.com/codex/tasks/task_e_68709355105c8333ad36378faf943d25