### PR TITLE
Fix Playwright shutdown

### DIFF
--- a/src/test/java/com/example/tests/BaseTest.java
+++ b/src/test/java/com/example/tests/BaseTest.java
@@ -19,12 +19,14 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 public abstract class BaseTest {
     protected Injector injector;
     protected Browser browser;
+    protected com.microsoft.playwright.Playwright playwright;
     protected BrowserContext context;
     protected Page page;
 
     @BeforeAll
     void setUpBase() {
         injector = Guice.createInjector(new PlaywrightModule());
+        playwright = injector.getInstance(com.microsoft.playwright.Playwright.class);
         browser = injector.getInstance(Browser.class);
     }
 
@@ -48,6 +50,9 @@ public abstract class BaseTest {
     void tearDownBase() {
         if (browser != null) {
             browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
         }
         if (injector != null) {
             injector = null;


### PR DESCRIPTION
## Summary
- close Playwright instance after tests

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870968017b08333b5ecb61165fd8f4b