### PR TITLE
Fix parallel context sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Tests run in parallel by default. The parallel execution settings are defined in
 parallel threads by editing the property
 `junit.jupiter.execution.parallel.config.fixed.parallelism` in this file.
 
+Each test class shares a single browser instance created in `BaseTest`. The
+setup methods create a new browser context and page for every test method so
+parallel execution is safe.
+
 If you want to observe browser windows during execution, set `headless=false`
 in `src/main/resources/config.properties`.
 

--- a/src/test/java/com/example/tests/BaseTest.java
+++ b/src/test/java/com/example/tests/BaseTest.java
@@ -10,20 +10,18 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Execution(ExecutionMode.CONCURRENT)
 public abstract class BaseTest {
-    protected Injector injector;
-    protected Browser browser;
+    protected static Injector injector;
+    protected static Browser browser;
     protected BrowserContext context;
     protected Page page;
 
     @BeforeAll
-    void setUpBase() {
+    static void setUpBase() {
         injector = Guice.createInjector(new PlaywrightModule());
         browser = injector.getInstance(Browser.class);
     }
@@ -45,7 +43,7 @@ public abstract class BaseTest {
     }
 
     @AfterAll
-    void tearDownBase() {
+    static void tearDownBase() {
         if (browser != null) {
             browser.close();
         }


### PR DESCRIPTION
## Summary
- share browser at class level only
- clarify parallel test behaviour in README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870968017b08333b5ecb61165fd8f4b